### PR TITLE
Changes from crrev.com/1584583003

### DIFF
--- a/telemetry/telemetry/internal/backends/chrome_inspector/tracing_backend_unittest.py
+++ b/telemetry/telemetry/internal/backends/chrome_inspector/tracing_backend_unittest.py
@@ -23,9 +23,6 @@ class TracingBackendTest(tab_test_case.TabTestCase):
   @classmethod
   def CustomizeBrowserOptions(cls, options):
     options.AppendExtraBrowserArgs([
-        # Memory maps currently cannot be retrieved on sandboxed processes.
-        # See crbug.com/461788.
-        '--no-sandbox',
 
         # Workaround to disable periodic memory dumps. See crbug.com/513692.
         '--enable-memory-benchmarking'


### PR DESCRIPTION
Remove --no-sandbox flag from command line for telemetry.
Now that the browser is able to dump for child processes the
--no-sandbox flag is not required for getting memory statistics. So,
this is removed form the telemetry unittests.

See crbug.com/461788
